### PR TITLE
Minor fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Create an accessor using this taskmanager like so:
 ```
 (let ((acceptor (make-instance 'tbnl:easy-acceptor
                                  :port 4242
-                                 :taskmaster (make-instance 'gserver-tmgr
+                                 :taskmaster (make-instance 'cl-tbnl-gserver-tmgr.tmgr:gserver-tmgr
                                                             :max-thread-count 8))))
-  (tbnl:start acceptor)
+  (tbnl:start acceptor))
 ```
 
 With `:max-thread-count` you can control how many `gservers` should be spawned.


### PR DESCRIPTION
Howdy. Hope the weather in Germany is treating you nice. I'm eager to try out
your library, but after getting it to load, I'm running into a bunch of error
conditions. I reproduced the steps below,

``` common-lisp
CL-USER> (asdf:load-system :cl-tbnl-gserver-tmgr)
WARNING: System definition file #P"/home/ben/quicklisp/dists/quicklisp/software/hunchentoot-v1.3.0/hunchentoot.asd" contains definition for system "hunchentoot-test". Please only define "hunchentoot" and secondary systems with a name starting with "hunchentoot/" (e.g. "hunchentoot/test") in that file.
WARNING: System definition file #P"/home/ben/quicklisp/dists/quicklisp/software/hunchentoot-v1.3.0/hunchentoot.asd" contains definition for system "hunchentoot-dev". Please only define "hunchentoot" and secondary systems with a name starting with "hunchentoot/" (e.g. "hunchentoot/test") in that file.
;;; Computing Hangul syllable names
WARNING: redefining LOG4CL-IMPL:APPENDER-ADDED in DEFGENERIC
WARNING: redefining LOG4CL-IMPL:APPENDER-REMOVED in DEFGENERIC
WARNING: redefining LOG4CL-IMPL::PROPERTY-ALIST in DEFGENERIC
T
CL-USER>
TMGR> (let ((acceptor (make-instance 'tbnl:easy-acceptor
                                 :port 4242
                                 :taskmaster (make-instance 'gserver-tmgr
                                                            :max-thread-count 8))))
  (tbnl:start acceptor))
 <INFO> [12:55:17] cl-tbnl-gserver-tmgr.tmgr tmgr.lisp () - Spawning 8 routees.
execute acceptor...
#<EASY-ACCEPTOR (host *, port 4242)>
<ERROR> [> [COMMON-LISP-USER] ] actor-40a: error8: erior conditioiseas raised:
invalid number of a:guments: 3


<ERROR> [COMMON-LISP-USER] actor-404: error condition was raised:
invalid number of arguments: 3


<ERROR> [COMMON-LISP-USER] actor-404: error condition was raised:
invalid number of arguments: 3
:guments: 3

<ERROR> [COMMON-LISP-USER] actor-408: error condition was raised:
invalid number of arguments: 3

<ERROR> [COMMON-LISP-USER] actor-406: error condition was raised:
invalid number of arguments: 3

<ERROR> [COMMON-LISP-USER] actor-402: error condition was raised:
invalid number of arguments: 3

<ERROR> [COMMON-LISP-USER] actor-396: error condition was raised:
invalid number of arguments: 3


<ERROR> [COMMON-LISP-USER] actor-402: error condition was raised:
invalid number of arguments: 3

<ERROR> [COMMON-LISP-USER] actor-396: error condition was raised:
invalid number of arguments: 3

<ERROR> [COMMON-LISP-USER] actor-400: error condition was raised:
invalid number of arguments: 3
```

I fixed some minor issues but I have a feeling I'm missing something. Any
pointers? Thanks for your time,